### PR TITLE
Add option to not hide children chapters

### DIFF
--- a/_layouts/website/summary.html
+++ b/_layouts/website/summary.html
@@ -25,7 +25,7 @@
 
             {% if article.articles.length > 0 %}
             <ul class="articles">
-                {% if articleToString.indexOf('"'+file.path) > -1 %} {% set showLevels = true %} {% endif %}
+                {% if articleToString.indexOf('"'+file.path) > -1 and not config.pluginsConfig["theme-gestalt "].doNotHideChildrenChapters %} {% set showLevels = true %} {% endif %}
                 {{ articles(article.articles, showLevels ) }}
             </ul>
             {% endif %}

--- a/package.json
+++ b/package.json
@@ -1,54 +1,54 @@
 {
-  "name": "gitbook-plugin-theme-gestalt",
-  "description": "A configurable theme for GitBook",
-  "main": "./index.js",
-  "version": "1.0.2",
-  "engines": {
-    "gitbook": ">=3.0.0"
-  },
-  "devDependencies": {
-    "browser-sync": "^2.18.12",
-    "browserify": "13.1.0",
-    "font-awesome": "4.6.3",
-    "gulp": "github:gulpjs/gulp#4.0",
-    "gulp-browserify": "^0.5.1",
-    "gulp-concat": "^2.6.1",
-    "gulp-exec": "^2.1.3",
-    "gulp-ignore": "^2.0.2",
-    "gulp-rename": "^1.2.2",
-    "gulp-sass": "^3.1.0",
-    "jquery": "3.1.1",
-    "merge-stream": "^1.0.1"
-  },
-  "scripts": {
-    "prepublish": "gulp build"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/antonlegoo/gitbook-plugin-theme-gestalt"
-  },
-  "author": "Anton Legoo <azeven@gmail.com>",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/antonlegoo/gitbook-plugin-theme-gestalt/issues"
-  },
-  "gitbook": {
-    "properties": {
-      "styles": {
-        "type": "object",
-        "title": "Custom Stylesheets",
+    "name": "gitbook-plugin-theme-gestalt",
+    "description": "A configurable theme for GitBook",
+    "main": "./index.js",
+    "version": "1.0.3",
+    "engines": {
+        "gitbook": ">=3.0.0"
+    },
+    "devDependencies": {
+        "browser-sync": "^2.18.12",
+        "browserify": "13.1.0",
+        "font-awesome": "4.6.3",
+        "gulp": "github:gulpjs/gulp#4.0",
+        "gulp-browserify": "^0.5.1",
+        "gulp-concat": "^2.6.1",
+        "gulp-exec": "^2.1.3",
+        "gulp-ignore": "^2.0.2",
+        "gulp-rename": "^1.2.2",
+        "gulp-sass": "^3.1.0",
+        "jquery": "3.1.1",
+        "merge-stream": "^1.0.1"
+    },
+    "scripts": {
+        "prepublish": "gulp build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/antonlegoo/gitbook-plugin-theme-gestalt"
+    },
+    "author": "Anton Legoo <azeven@gmail.com>",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/antonlegoo/gitbook-plugin-theme-gestalt/issues"
+    },
+    "gitbook": {
         "properties": {
-          "website": {
-            "title": "Stylesheet for website output",
-            "default": "styles/website.css"
-          }
+            "styles": {
+                "type": "object",
+                "title": "Custom Stylesheets",
+                "properties": {
+                    "website": {
+                        "title": "Stylesheet for website output",
+                        "default": "styles/website.css"
+                    }
+                }
+            },
+            "showLevel": {
+                "type": "boolean",
+                "title": "Show level indicator in TOC",
+                "default": false
+            }
         }
-      },
-      "showLevel": {
-        "type": "boolean",
-        "title": "Show level indicator in TOC",
-        "default": false
-      }
     }
-  }
 }


### PR DESCRIPTION
The way that the hide of children chapters may collide with other gitbook plugins.
Now there is an option to disable to auto hide of children chapters non active chapter.